### PR TITLE
Add command history and clear screen support

### DIFF
--- a/components/CvTerminalHistory.vue
+++ b/components/CvTerminalHistory.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-for="historyItem in commandHistory.items">
+  <div v-for="historyItem in getCommandHistoryItems()">
     <span class="terminal-prefix">></span>
     <code class="text-neutral-100">{{ historyItem.command }}</code>
     <div class="terminal-output">
@@ -15,5 +15,5 @@
 <script setup lang="ts">
 import { useCommandHistoryStore } from '~~/store/commandHistory'
 
-const commandHistory = useCommandHistoryStore()
+const { getItems: getCommandHistoryItems } = useCommandHistoryStore()
 </script>

--- a/components/CvTerminalInput.vue
+++ b/components/CvTerminalInput.vue
@@ -21,7 +21,7 @@
 import { useCommandHistoryStore } from '~~/store/commandHistory'
 
 const { executeCommand } = useCommands()
-const { previousCommand, nextCommand } = useCommandHistoryStore()
+const { getPreviousCommand, getNextCommand } = useCommandHistoryStore()
 
 let terminalInput = $ref('')
 
@@ -32,12 +32,12 @@ const onTerminalEnterKey = () => {
 }
 
 const onTerminalUpKey = (event: KeyboardEvent) => {
-  terminalInput = previousCommand() || terminalInput
+  terminalInput = getPreviousCommand() || terminalInput
   event.preventDefault()
 }
 
 const onTerminalDownKey = (event: KeyboardEvent) => {
-  terminalInput = nextCommand() || ''
+  terminalInput = getNextCommand() || ''
   event.preventDefault()
 }
 </script>

--- a/components/CvTerminalInput.vue
+++ b/components/CvTerminalInput.vue
@@ -9,13 +9,19 @@
         class="terminal-input"
         autofocus
         @keyup.enter="onTerminalEnterKey"
+        @keydown.up="onTerminalUpKey"
+        @keydown.down="onTerminalDownKey"
+        @keydown.tab="($event) => $event.preventDefault()"
       />
     </code>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useCommandHistoryStore } from '~~/store/commandHistory'
+
 const { executeCommand } = useCommands()
+const { previousCommand, nextCommand } = useCommandHistoryStore()
 
 let terminalInput = $ref('')
 
@@ -23,6 +29,16 @@ const onTerminalEnterKey = () => {
   if (!terminalInput) return
   executeCommand(terminalInput)
   terminalInput = ''
+}
+
+const onTerminalUpKey = (event: KeyboardEvent) => {
+  terminalInput = previousCommand() || terminalInput
+  event.preventDefault()
+}
+
+const onTerminalDownKey = (event: KeyboardEvent) => {
+  terminalInput = nextCommand() || ''
+  event.preventDefault()
 }
 </script>
 

--- a/composables/commands/getCommandOutput.ts
+++ b/composables/commands/getCommandOutput.ts
@@ -3,7 +3,7 @@ import { AVAILABLE_COMMANDS } from '~~/constants/messages'
 import cv from '~~/data/cv'
 import { Command } from '~~/types/command'
 
-export function getCommandOutput(command: Command): string | undefined {
+export function getCommandOutput(command: Command): string {
   switch (command.name) {
     case AVAILABLE_COMMANDS.help.name:
       return getHelpOutput()
@@ -19,6 +19,8 @@ export function getCommandOutput(command: Command): string | undefined {
       return 'Check the links below the terminal.'
     case AVAILABLE_COMMANDS.experience.name:
       return getExperienceOutput()
+    default:
+      return ''
   }
 }
 

--- a/constants/messages.ts
+++ b/constants/messages.ts
@@ -66,4 +66,10 @@ export const AVAILABLE_COMMANDS = {
     usage: 'experience',
     aliases: ['e', 'xp'],
   },
+  clear: {
+    name: 'clear',
+    description: 'Clears the screen.',
+    usage: 'clear',
+    aliases: ['cls'],
+  },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexandrupero.github.io",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "nuxt dev",

--- a/store/commandHistory.ts
+++ b/store/commandHistory.ts
@@ -24,19 +24,15 @@ export const useCommandHistoryStore = defineStore('commandHistory', () => {
     getItems(): Readonly<CommandHistory[]> {
       return readonly(state.items)
     },
-    nextCommand(): Readonly<string> | null {
-      if (index < previousCommands.length) index++ // unless we're at the end
-      // will return null if we're at the end
-      if (index === previousCommands.length) return null
+    getNextCommand(): Readonly<string> | null {
+      if (index < previousCommands.length) index++
 
-      return previousCommands[index]
+      return previousCommands[index] || null
     },
-    previousCommand(): Readonly<string> | null {
-      // will return null for an empty array or if we're at the beginning
-      if (previousCommands.length === 0 || index === 0) return null
-      index-- // unless we're at the beginning
+    getPreviousCommand(): Readonly<string> | null {
+      if (index > 0) index--
 
-      return previousCommands[index]
+      return previousCommands[index] || null
     },
   }
 

--- a/store/commandHistory.ts
+++ b/store/commandHistory.ts
@@ -9,9 +9,6 @@ export const useCommandHistoryStore = defineStore('commandHistory', () => {
   const previousCommands = $ref([] as string[])
 
   const actions = {
-    getItems(): Readonly<CommandHistory[]> {
-      return readonly(state.items)
-    },
     clearItems(): void {
       state.items = []
     },
@@ -20,6 +17,12 @@ export const useCommandHistoryStore = defineStore('commandHistory', () => {
       previousCommands.push(commandHistory.command)
       // move past the end, so the previous command is the last command
       index = previousCommands.length
+    },
+  }
+
+  const getters = {
+    getItems(): Readonly<CommandHistory[]> {
+      return readonly(state.items)
     },
     nextCommand(): Readonly<string> | null {
       if (index < previousCommands.length) index++ // unless we're at the end
@@ -37,5 +40,5 @@ export const useCommandHistoryStore = defineStore('commandHistory', () => {
     },
   }
 
-  return { ...actions }
+  return { ...actions, ...getters }
 })

--- a/store/commandHistory.ts
+++ b/store/commandHistory.ts
@@ -1,7 +1,41 @@
 import { CommandHistory } from '~~/types/commandHistory'
 
-export const useCommandHistoryStore = defineStore('commandHistory', {
-  state: () => ({
+export const useCommandHistoryStore = defineStore('commandHistory', () => {
+  const state = $ref({
     items: [] as CommandHistory[],
-  }),
+  })
+
+  let index = $ref(0)
+  const previousCommands = $ref([] as string[])
+
+  const actions = {
+    getItems(): Readonly<CommandHistory[]> {
+      return readonly(state.items)
+    },
+    clearItems(): void {
+      state.items = []
+    },
+    add(commandHistory: CommandHistory): void {
+      state.items.push(commandHistory)
+      previousCommands.push(commandHistory.command)
+      // move past the end, so the previous command is the last command
+      index = previousCommands.length
+    },
+    nextCommand(): Readonly<string> | null {
+      if (index < previousCommands.length) index++ // unless we're at the end
+      // will return null if we're at the end
+      if (index === previousCommands.length) return null
+
+      return previousCommands[index]
+    },
+    previousCommand(): Readonly<string> | null {
+      // will return null for an empty array or if we're at the beginning
+      if (previousCommands.length === 0 || index === 0) return null
+      index-- // unless we're at the beginning
+
+      return previousCommands[index]
+    },
+  }
+
+  return { ...actions }
 })


### PR DESCRIPTION
* Expand the Pinia store to support multiple actions/getters: getting a readonly version of the state, clearing the state, adding a command to the state, getting the next and previous commands (the previous commands are stored in a separate list so that we can clear the state, but still have a history of the commands that were ran)
* closes #14 
* closes #17 (but will keep the history for navigating through keyUp/keyDown) 
* Prevent default on tab key so the input doesn't get defocused (for consistency with an actual terminal)
* Prevent default on up/down in the input, so the default behavior doesn't get executed (for consistency with an actual terminal)
* Refactored the `useCommands` composable to make the intent clearer and execute the command after adding to command history